### PR TITLE
PDF/A compliant

### DIFF
--- a/tesi-config.tex
+++ b/tesi-config.tex
@@ -105,7 +105,7 @@
     colorlinks=true,
     linktocpage=true,
     pdfstartpage=1,
-    pdfstartview=FitV,
+    pdfstartview=,
     % decommenta la riga seguente per avere link in nero (per esempio per la stampa in bianco e nero)
     %colorlinks=false, linktocpage=false, pdfborder={0 0 0}, pdfstartpage=1, pdfstartview=FitV,
     breaklinks=true,

--- a/tesi.tex
+++ b/tesi.tex
@@ -19,6 +19,16 @@
 % !TEX root = tesi.tex
 % !TEX spellcheck = it-IT
 
+% PDF/A filecontents
+\RequirePackage{filecontents}
+\begin{filecontents*}{\jobname.xmpdata}
+  \Title{Document’s title}
+  \Author{Author’s name}
+  \Language{it-IT}
+  \Subject{The abstract, or short description.}
+  \Keywords{keyword1\sep keyword2\sep keyword3}
+\end{filecontents*}
+
 \documentclass[10pt,                    % corpo del font principale
                a4paper,                 % carta A4
                twoside,                 % impagina per fronte-retro
@@ -30,6 +40,14 @@
 %**************************************************************
 % Importazione package
 %************************************************************** 
+
+\PassOptionsToPackage{dvipsnames}{xcolor} % colori PDF/A
+
+\usepackage{colorprofiles}
+
+\usepackage[a-2b,mathxmp]{pdfx}[2018/12/22]
+                                        % configurazione PDF/A
+                                        % validare in https://www.pdf-online.com/osa/validate.aspx
 
 %\usepackage{amsmath,amssymb,amsthm}    % matematica
 
@@ -71,14 +89,11 @@
 \usepackage{mparhack,fixltx2e,relsize}  % finezze tipografiche
 
 \usepackage{nameref}                    % visualizza nome dei riferimenti                                      
-
 \usepackage[font=small]{quoting}        % citazioni
 
 \usepackage{subfig}                     % sottofigure, sottotabelle
 
 \usepackage[italian]{varioref}          % riferimenti completi della pagina
-
-\usepackage[dvipsnames]{xcolor}         % colori
 
 \usepackage{booktabs}                   % tabelle                                       
 \usepackage{tabularx}                   % tabelle di larghezza prefissata                                    


### PR DESCRIPTION
Aggiunto codice per pacchetto che genera documenti conformi allo standard PDF/A.

Testato inoltre su https://www.pdf-online.com/osa/validate.aspx .

In questo modo UniWeb può accettare la tesi.