### PR TITLE
Corretti titoli glossario e acronimi in table of contents

### DIFF
--- a/glossario.tex
+++ b/glossario.tex
@@ -2,8 +2,6 @@
 %**************************************************************
 % Acronimi
 %**************************************************************
-\renewcommand{\acronymname}{Acronimi e abbreviazioni}
-
 \newacronym[description={\glslink{apig}{Application Program Interface}}]
     {api}{API}{Application Program Interface}
 
@@ -13,8 +11,6 @@
 %**************************************************************
 % Glossario
 %**************************************************************
-%\renewcommand{\glossaryname}{Glossario}
-
 \newglossaryentry{apig}
 {
     name=\glslink{api}{API},

--- a/tesi-config.tex
+++ b/tesi-config.tex
@@ -85,8 +85,8 @@
 %**************************************************************
 % Impostazioni di glossaries
 %**************************************************************
-\input{glossario} % database di termini
 \makeglossaries
+\input{glossario} % database di termini
 
 
 %**************************************************************

--- a/tesi.tex
+++ b/tesi.tex
@@ -149,6 +149,7 @@
 % Materiale finale
 %**************************************************************
 \backmatter
-\printglossaries
+\printglossary[type=\acronymtype, title=Acronimi e abbreviazioni, toctitle=Acronimi e abbreviazioni]
+\printglossary[type=main, title=Glossario, toctitle=Glossario]
 \input{inizio-fine/bibliografia}
 \end{document}


### PR DESCRIPTION
<!--

Hai letto il codice di condotta del FIUP? Inviando una Pull Request dichiari di accettarlo e di rispettarlo, ciò include trattare tutti con rispetto: https://github.com/FIUP/Getting_Started/blob/master/CODE_OF_CONDUCT.md

Hai dubbi o domande? Ti serve aiuto? Dai un'occhiata ai nostri gruppi social: https://github.com/FIUP/Getting_Started/blob/master/FIUP_Rules.md#il-fiup-nei-social

-->

### Descrizione delle modifiche
- Sostituito il comando `\printglossaries` con due `\printglossary` separati, per glossario e acronimi. Il comando `\printglossary` è più flessibile e permette di modificare i titoli del paragrafo e della table of contents. Inoltre, permette di eseguire le sopracitate operazioni in un unico comando, invece che in comandi separati (non esattamente puliti, oltretutto) sparsi in file separati, migliorando la manutenibilità del template.
- Applicate le modifiche proposte in https://github.com/FIUP/Thesis-template/issues/2.

### Benefici
Non ci sono più titoli in inglese nei paragrafi o nella table of contents

### Possibili regressioni
Potrebbero sorgere problemi relativi al glossario e gli acronimi.

### Issue coinvolte
Fixes #2