### PR TITLE
Add latexmk configuration for supporting glossaries

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -1,0 +1,12 @@
+# Taken from http://mirrors.ctan.org/support/latexmk/example_rcfiles/glossaries_latexmkrc
+
+add_cus_dep( 'acn', 'acr', 0, 'makeglossaries' );
+add_cus_dep( 'glo', 'gls', 0, 'makeglossaries' );
+$clean_ext .= " acr acn alg glo gls glg bbl ist";
+
+sub makeglossaries {
+    my ($base_name, $path) = fileparse( $_[0] );
+    my @args = ( "-q", "-d", $path, $base_name );
+    if ($silent) { unshift @args, "-q"; }
+    return system "makeglossaries", "-d", $path, $base_name;
+}


### PR DESCRIPTION
### Descrizione delle modifiche

È stato aggiunto il file `latexmkrc` contenente la configurazione necessaria a `latexmk` per essere compatibile con il pacchetto `glossaries` usato nel template. Il file segue l'esempio ufficiale di latexmk http://mirrors.ctan.org/support/latexmk/example_rcfiles/glossaries_latexmkrc con l'aggiunta delle estensioni `bbl` e `ist` per la pulizia dei file in modo da emulare il comportamento di `clean.bat`.

<!--

Dobbiamo essere in grado di capire il perché della modifica da questa descrizione. Se non si riesce a capire cosa faccia il codice da questa descrizione, la pull request potrebbe essere chiusa secondo la discrezione dei manutentori. Tieni a mente che i manutentori che controlleranno la PR potrebbero non avere familiarità o non aver lavorato recentemente al progetto, quindi per favore aiutali a capire 
l'impatto delle modifiche. 
-->

### Design Alternativi

<!-- Spiega se e quali alternative sarebbero da prendere o sono state prese in considerazione. Nel caso di più scelte, spiega perché le ragioni che hanno condotto a quelle adottate. -->

Come descritto in http://mirrors.ctan.org/support/latexmk/example_rcfiles/glossaries_latexmkrc esiste una configurazione alternativa più veloce ma con delle limitazioni.

### Benefici

<!-- Quali benefici porterà la modifica adottata? -->

Sarà possibile utilizzare `latexmk` per compilare il template della tesi, evitando quindi configurazioni aggiuntive nei vari IDE.

### Possibili regressioni

<!-- Quali sono i possibili side-effect o impatti negativi delle modifiche? -->

La configurazione proposta potrebbe avere degli edge case non testati e quindi dare la falsa sensazione che sia equivalente all'uso degli script esistenti. Non sono però attualmente a conoscenza di esempi di tali edge case.

### Issue coinvolte

<!-- Scrivi qui, se le modifiche riguardano alcune issue -->

Nessuna