### PR TITLE
Revert "`cm-super` explicit dependency"

### DIFF
--- a/tesi.tex
+++ b/tesi.tex
@@ -99,7 +99,6 @@
 \usepackage{tabularx}                   % tabelle di larghezza prefissata                                    
 \usepackage{longtable}                  % tabelle su più pagine                                        
 \usepackage{ltxtable}                   % tabelle su più pagine e adattabili in larghezza
-\usepackage{cm-super}                   % font scalabili, corregge https://github.com/FIUP/Thesis-template/issues/1
 
 \usepackage[toc, acronym]{glossaries}   % glossario
                                         % per includerlo nel documento bisogna:


### PR DESCRIPTION
Reverts FIUP/Thesis-template#11

# Problema
Evidentemente il package cm-super non può essere dichiarato esplicitamente in un file .tex, ma viene usato automaticamente con la direttiva `\usepackage[T1]{fontenc}`.

Perché la compilazione vada a buon fine è necessario comunque che il pacchetto sia installato.

# Soluzioni alternative
Usare il package lmodern, che fornisce anch'esso dei font scalabili.

# Issue
Reopens #1