### PR TITLE
Printable version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,4 +223,4 @@ TSWLatexianTemp*
 build/
 
 # produced pdf
-tesi.pdf
+tesi*.pdf

--- a/config/tesi-config.tex
+++ b/config/tesi-config.tex
@@ -65,13 +65,10 @@
 \hypersetup{
     %hyperfootnotes=false,
     %pdfpagelabels,
-    %draft,	% = elimina tutti i link (utile per stampe in bianco e nero)
     colorlinks=true,
     linktocpage=true,
     pdfstartpage=1,
     pdfstartview=,
-    % decommenta la riga seguente per avere link in nero (per esempio per la stampa in bianco e nero)
-    %colorlinks=false, linktocpage=false, pdfborder={0 0 0}, pdfstartpage=1, pdfstartview=FitV,
     breaklinks=true,
     pdfpagemode=UseNone,
     pageanchor=true,
@@ -88,8 +85,12 @@
     linkcolor=RoyalBlue,
     citecolor=webgreen
     %pagecolor=RoyalBlue,
-    %urlcolor=Black, linkcolor=Black, citecolor=Black, %pagecolor=Black,
 }
+
+% Delete all links and show them in black
+\if \isprintable 1
+    \hypersetup{draft}
+\fi
 
 % Itemize symbols
 %\renewcommand{\labelitemi}{$\ast$}

--- a/tesi-stampabile.tex
+++ b/tesi-stampabile.tex
@@ -1,0 +1,12 @@
+\documentclass[
+    10pt,       % fontsize
+    twoside,    % asymmetric pagination, for printed view
+    openright,  % open chapeters on right page
+    a4paper,
+    english,
+    italian,
+]{book}
+
+\newcommand{\isprintable}{1}
+
+\input{tesi}

--- a/tesi.tex
+++ b/tesi.tex
@@ -1,11 +1,14 @@
-\documentclass[
-    10pt,       % fontsize
-    twoside,    % asymmetric pagination
-    openright,  % open chapeters on right page
-    a4paper,
-    english,
-    italian,
-]{book}
+\ifdefined \isprintable
+\else
+    \documentclass[
+        10pt,       % fontsize
+        oneside,    % symmetric pagination, for digital view
+        a4paper,
+        english,
+        italian,
+    ]{book}
+    \newcommand{\isprintable}{0}
+\fi
 
 \input{config/packages}
 


### PR DESCRIPTION
<!--

Hai letto il codice di condotta del FIUP? Inviando una Pull Request dichiari di accettarlo e di rispettarlo, ciò include trattare tutti con rispetto: https://github.com/FIUP/Getting_Started/blob/master/CODE_OF_CONDUCT.md

Hai dubbi o domande? Ti serve aiuto? Dai un'occhiata ai nostri gruppi social: https://github.com/FIUP/Getting_Started/blob/master/FIUP_Rules.md#il-fiup-nei-social

-->

### Descrizione delle modifiche

<!--

Dobbiamo essere in grado di capire il perché della modifica da questa descrizione. Se non si riesce a capire cosa faccia il codice da questa descrizione, la pull request potrebbe essere chiusa secondo la discrezione dei manutentori. Tieni a mente che i manutentori che controlleranno la PR potrebbero non avere familiarità o non aver lavorato recentemente al progetto, quindi per favore aiutali a capire l'impatto delle modifiche.
-->

Durante la redazione e la consegna della tesi si ha sempre a che fare con una versione digitale della tesi, in versione PDF. Non essendo richiesta dai professori una verione cartacea non è più rilevante avere ottimizzazioni per i margini e l'impaginazione nel template di default. Il template quindi è stato diviso in due versioni:
* Stampabile:
    - utilizza i margini asimmetrici, ottimizzati per la rilegatura che venivano già utilizzati precedentemente dal template;
    - elimina tutti i link ipertestuali, colorandoli in nero come il resto del testo. In una versione cartacea della tesi non è di interesse avere i link evidenziati;
    - inserisce pagine bianche dove necessario, in modo da mantenere l'apertura dei capitoli nella pagina a destra, come veniva già fatto nel template.
* Digitale:
    - Mantiene i margini standard, simmetrici. La larghezza del contenuto è identica a quella della versione stampabile, quindi non causa incongruenze tra le due versioni (le pagine sono tutte identiche, tranne per la larghezza dei margini);
    - Non apre i capitoli nelle pagine a destra. In una versione digitale non è sensato distinguere pagine sinistre da destre, essendo che la lettura avviene, molto probabilmente, pagina per pagina in un lettore PDF. Grazie a questo vengono rimosse tutte le pagine bianche, che non sono di alcuna utilità in una versione digitale.

La versione digitale ora è la predefinita. La versione stampabile può essere ottenuta compilando il file `tesi-stampabile.tex` con il comando
```bash
latexmk tesi-stampabile.tex
```

### Design Alternativi

<!-- Spiega se e quali alternative sarebbero da prendere o sono state prese in considerazione. Nel caso di più scelte, spiega perché le ragioni che hanno condotto a quelle adottate. -->

Si potrebbe rendere la versione stampabile la predefinita.

### Possibili regressioni

<!-- Quali sono i possibili side-effect o impatti negativi delle modifiche? -->

Non è più intuitivo quale sia il file principale del template, essendo la radice diramata in due file diversi (`tesi.tex` e `tesi-stampabile.tex`, in base alla versione che si vuole compilare).
