### PR TITLE
Variables import fix

### DIFF
--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -22,6 +22,9 @@
 \setlength{\parindent}{14pt}    % first row indentation
 \setlength{\parskip}{0pt}       % paragraphs spacing
 
+% Load variables
+\input{config/variables}
+
 \input{appendix/glossary-entries}
 \makeglossaries
 

--- a/config/variables.tex
+++ b/config/variables.tex
@@ -11,6 +11,7 @@
 \newcommand{\myTime}{Mese AAAA}
 
 % PDF file metadata fields
+% when updating them delete the build directory, otherwise they won't change
 \RequirePackage{filecontents}
 \begin{filecontents*}{\jobname.xmpdata}
   \Title{Document's title}


### PR DESCRIPTION
### Descrizione delle modifiche
Importa il file `variables.tex` in `thesis-config.tex`, caricando effettivamente le variabili e permettendo la corretta compilazione (rotta nella PR #23). È stato anche aggiunto un commento che spiega come risolvere il problema in cui i campi metadata del PDF non cambiano ricompilando il file