### PR TITLE
Use GitHub Actions workflow

### DIFF
--- a/.github/workflows/pdf-compile.yaml
+++ b/.github/workflows/pdf-compile.yaml
@@ -1,0 +1,16 @@
+name: pdf-compile
+on:
+    push:
+        branches:
+            - master
+    workflow_dispatch:
+    pull_request:
+jobs:
+    pdf-compile:
+        runs-on: ubuntu-latest
+        container: aergus/latex:latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - name: PDF compile
+              run: latexmk thesis.tex printable-thesis.tex

--- a/.github/workflows/pdf-compile.yaml
+++ b/.github/workflows/pdf-compile.yaml
@@ -1,8 +1,5 @@
 name: pdf-compile
 on:
-    push:
-        branches:
-            - master
     workflow_dispatch:
     pull_request:
 jobs:


### PR DESCRIPTION
### Descrizione delle modifiche
In alcune pull request aperte e approvate c'erano delle dimenticanze che comportavano errori di compilazione, trasportati poi nel branch `master`.
Questo poi rende necessario eseguire altre pull request correttive, lasciando nel frattempo il branch `master` con errori al suo interno.

Questa pull request aggiunge una action automatica, che viene attivata ad ogni commit eseguito su una pull request e sul branch `master`. Si assicura che entrambe le versioni del documento compilino correttamente.

Dalle impostazioni del repository sarà anche possibile bloccare tentativi di merge su pull request che non soddisfano il requisito

EDIT: è stato rimosso il check per i commit sul branch `master`, perché la configurazione sarebbe stata ereditata anche da tutti i fork del template (anche privati, quindi i veri progetti di tesi).
Potrebbe non essere un grande problema di per sè, anzi un pregio, ma GitHub impone un limite di minutaggio di utilizzo delle actions nei repo privati. C'è il rischio che un utente possa terminarlo senza rendersene conto a forza di numerosi commit consecutivi (che richiamerebbero ognuno la sua action)