### PR TITLE
Filecontents warning fix

### DIFF
--- a/config/variables.tex
+++ b/config/variables.tex
@@ -12,7 +12,6 @@
 
 % PDF file metadata fields
 % when updating them delete the build directory, otherwise they won't change
-\RequirePackage{filecontents}
 \begin{filecontents*}{\jobname.xmpdata}
   \Title{Document's title}
   \Author{Author's name}

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,6 @@ choco install texlive
 This template is pretty big and complex, therefore it requires a lot of specific packages that may not be shipped with your installation of TeX Live by default.
 
 Here's the complete list of packages that you'll need, in order to be able to successfully compile your thesis:
-- filecontents
 - pdfx
 - xcolor
 - xmpincl
@@ -69,7 +68,7 @@ Just copy and paste the following command in your terminal.
 ```bash
 sudo tlmgr update --self
 sudo tlmgr update --all
-sudo tlmgr install filecontents pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting subfig booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk
+sudo tlmgr install pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting subfig booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk
 ```
 
 As you can see `tlmgr` asks for admin rights, so you'll need to use `sudo` on Linux/macOS, while on Windows you have to [open a command prompt instance as admin](https://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/) and omit the `sudo` at the beginning of the lines.


### PR DESCRIPTION
### Descrizione delle modifiche
Nella compilazione del documento viene riportato questo warning:
```
Package filecontents Warning: This package is obsolete. Disabling it and
(filecontents)                passing control to the filecontents environment
(filecontents)                defined by the LaTeX kernel.
```

Questo è causato dall'importazione del package 'filecontents', che non è più necessaria dal 1/10/2019, quando il package in questione è stato incluso nativamente nel kernel LaTeX, come riportato qui: https://tex.stackexchange.com/a/511507

L'importazione non è quindi più necessaria e, rimuovendola, il warning viene silenziato.

È stata anche aggiornata la lista delle dipendenze del progetto e il relativo comando per installarle, escludendo il package in questione