### PR TITLE
Page numbers on the bottom + improved header

### DIFF
--- a/config/packages.tex
+++ b/config/packages.tex
@@ -60,3 +60,4 @@
 \usepackage[backend=biber,style=verbose-ibid,hyperref,backref]{biblatex}
 
 \usepackage{layaureo}                   % margini ottimizzati per l'A4
+\usepackage{fancyhdr}

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -8,6 +8,23 @@
 % \renewcommand{\labelitemiii}{$\diamond$}
 % \renewcommand{\labelitemiv}{$\ast$}
 
+
+\let\Chaptermark\chaptermark
+% \Chaptername gives current chapter name
+\def\chaptermark#1{\def\Chaptername{#1}\Chaptermark{#1}}
+\makeatletter
+% \currentname gives the current section name
+\newcommand*{\currentname}{\@currentlabelname}
+\makeatother
+
+% Uncomment the following line for a different header/footer style
+% \pagestyle{fancy} \setlength{\headheight}{14.5pt}
+\fancyhead[L]{\fontsize{12}{14.5} \selectfont \thechapter. \Chaptername}
+\fancyhead[R]{\fontsize{12}{14.5} \selectfont \currentname}
+% Page number always in footer
+\cfoot{\thepage}
+
+
 % Custom hyphenation rules
 \hyphenation {
     e-sem-pio
@@ -21,23 +38,6 @@
 % see: http://wwwcdf.pd.infn.it/AppuntiLinux/a2547.htm
 \setlength{\parindent}{14pt}    % first row indentation
 \setlength{\parskip}{0pt}       % paragraphs spacing
-
-
-\let\Chaptermark\chaptermark
-% \Chaptername gives current chapter name
-\def\chaptermark#1{\def\Chaptername{#1}\Chaptermark{#1}}
-\makeatletter
-% \currentname gives the current section name
-\newcommand*{\currentname}{\@currentlabelname}
-\makeatother
-
-% Custom header and footer
-\pagestyle{fancy}
-\setlength{\headheight}{14.5pt}
-\fancyhead[L]{\fontsize{12}{14.5} \selectfont \thechapter. \Chaptername}
-\fancyhead[R]{\fontsize{12}{14.5} \selectfont \currentname}
-% Page number always in footer
-\cfoot{\thepage}
 
 
 % Load variables

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -8,16 +8,6 @@
 % \renewcommand{\labelitemiii}{$\diamond$}
 % \renewcommand{\labelitemiv}{$\ast$}
 
-% Header with current section and page number always in footer
-\makeatletter
-\newcommand*{\currentname}{\@currentlabelname}
-\makeatother
-\pagestyle{fancy}
-\setlength{\headheight}{14.5pt}
-\fancyhead{}
-\fancyhead[L]{\fontsize{12}{14.5} \selectfont \thesection \quad \currentname}
-\cfoot{\thepage}
-
 % Custom hyphenation rules
 \hyphenation {
     e-sem-pio
@@ -31,6 +21,24 @@
 % see: http://wwwcdf.pd.infn.it/AppuntiLinux/a2547.htm
 \setlength{\parindent}{14pt}    % first row indentation
 \setlength{\parskip}{0pt}       % paragraphs spacing
+
+
+\let\Chaptermark\chaptermark
+% \Chaptername gives current chapter name
+\def\chaptermark#1{\def\Chaptername{#1}\Chaptermark{#1}}
+\makeatletter
+% \currentname gives the current section name
+\newcommand*{\currentname}{\@currentlabelname}
+\makeatother
+
+% Custom header and footer
+\pagestyle{fancy}
+\setlength{\headheight}{14.5pt}
+\fancyhead[L]{\fontsize{12}{14.5} \selectfont \thechapter. \Chaptername}
+\fancyhead[R]{\fontsize{12}{14.5} \selectfont \currentname}
+% Page number always in footer
+\cfoot{\thepage}
+
 
 % Load variables
 \input{config/variables}

--- a/config/thesis-config.tex
+++ b/config/thesis-config.tex
@@ -8,6 +8,16 @@
 % \renewcommand{\labelitemiii}{$\diamond$}
 % \renewcommand{\labelitemiv}{$\ast$}
 
+% Header with current section and page number always in footer
+\makeatletter
+\newcommand*{\currentname}{\@currentlabelname}
+\makeatother
+\pagestyle{fancy}
+\setlength{\headheight}{14.5pt}
+\fancyhead{}
+\fancyhead[L]{\fontsize{12}{14.5} \selectfont \thesection \quad \currentname}
+\cfoot{\thepage}
+
 % Custom hyphenation rules
 \hyphenation {
     e-sem-pio

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Here's the complete list of packages that you'll need, in order to be able to su
 - cm-super
 - greek-fontenc
 - latexmk
+- fancyhdr
 
 You can install them manually using the TeX Live Manager (good luck!), or using the CLI utility counterpart `tlmgr`
 
@@ -68,7 +69,7 @@ Just copy and paste the following command in your terminal.
 ```bash
 sudo tlmgr update --self
 sudo tlmgr update --all
-sudo tlmgr install pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting subfig booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk
+sudo tlmgr install pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting subfig booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk fancyhdr
 ```
 
 As you can see `tlmgr` asks for admin rights, so you'll need to use `sudo` on Linux/macOS, while on Windows you have to [open a command prompt instance as admin](https://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/) and omit the `sudo` at the beginning of the lines.


### PR DESCRIPTION
Attualmente i numeri delle pagine vengono mostrati in basso e centrati solamente nella pagina di apertura dei capitoli, mentre in mezzo ai capitoli viene riportato sull'header

<img width="643" alt="Screenshot 2023-07-06 at 09 04 43" src="https://github.com/FIUP/Thesis-template/assets/70653968/0b3acad1-4266-4ed6-873f-57354b38129e">

Questo crea un po' di confusione e incosistenza (normalmente in LaTeX la numerazione delle pagine avviene in basso al centro), anche se è l'impostazione di default della classe "book".

Per modificare lo stile dell'header è necessario rivolgersi al package `fancyhdr`, che permette di applicare altre interessanti aggiunte. Per questo l'header è stato modificato come segue:
- Numero e titolo del capitolo sulla sinistra (non è necessario riportare "Capitolo", che anzi occupa solo spazio)
- Sezione principale di cui tratta la pagina
- Linea per separare l'header dal contenuto (non propriamente necessaria)
- Scritte non portate in maiuscolo e non in corsivo, come vengono riportate nel testo
 
<img width="646" alt="Screenshot 2023-07-06 at 09 14 02" src="https://github.com/FIUP/Thesis-template/assets/70653968/78e021a4-6a15-491d-a177-7538b14d540f">
