### PR TITLE
Aggiornati pacchetti obsoleti

### DIFF
--- a/config/packages.tex
+++ b/config/packages.tex
@@ -27,7 +27,7 @@
 
 \usepackage{emptypage}                  % pagine vuote senza testatina e piede di pagina
 
-\usepackage{epigraph}			        % per epigrafi
+\usepackage{epigraph}			              % per epigrafi
 
 \usepackage{eurosym}                    % simbolo dell'euro
 
@@ -41,12 +41,12 @@
 
 \usepackage{microtype}                  % microtipografia
 
-\usepackage{mparhack,relsize}  % finezze tipografiche
+\usepackage{mparhack,relsize}           % finezze tipografiche
 
 \usepackage{nameref}                    % visualizza nome dei riferimenti
 \usepackage[font=small]{quoting}        % citazioni
 
-\usepackage{subfig}                     % sottofigure, sottotabelle
+\usepackage{subcaption}                 % sottofigure, sottotabelle
 
 \usepackage[italian]{varioref}          % riferimenti completi della pagina
 

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -27,7 +27,7 @@
 
 \usepackage{emptypage}                  % pagine vuote senza testatina e piede di pagina
 
-\usepackage{epigraph}			              % per epigrafi
+\usepackage{epigraph}                         % per epigrafi
 
 \usepackage{eurosym}                    % simbolo dell'euro
 

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -4,7 +4,7 @@
 
 % PDF/A
 % validate in https://www.pdf-online.com/osa/validate.aspx
-\usepackage[a-2b,mathxmp]{pdfx}[2018/12/22]
+\usepackage[a-2b,mathxmp]{pdfx}
 
 %\usepackage{amsmath,amssymb,amsthm}    % matematica
 

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -21,7 +21,7 @@
 
 \usepackage{caption}                    % didascalie
 
-\usepackage{chngpage,calc}              % centra il frontespizio
+\usepackage{changepage,calc}            % centra il frontespizio
 
 \usepackage{csquotes}                   % gestisce automaticamente i caratteri (")
 

--- a/config/packages.tex
+++ b/config/packages.tex
@@ -27,7 +27,7 @@
 
 \usepackage{emptypage}                  % pagine vuote senza testatina e piede di pagina
 
-\usepackage{epigraph}                         % per epigrafi
+\usepackage{epigraph}                   % per epigrafi
 
 \usepackage{eurosym}                    % simbolo dell'euro
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,6 @@ Here's the complete list of packages that you'll need, in order to be able to su
 - mparhack
 - relsize
 - quoting
-- subfig
 - booktabs
 - glossaries
 - glossaries-italian
@@ -69,7 +68,7 @@ Just copy and paste the following command in your terminal.
 ```bash
 sudo tlmgr update --self
 sudo tlmgr update --all
-sudo tlmgr install pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting subfig booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk fancyhdr
+sudo tlmgr install pdfx xcolor xmpincl caption changepage csquotes emptypage epigraph nextpage eurosym layaureo listings microtype mparhack relsize quoting booktabs glossaries glossaries-italian glossaries-english biber biblatex babel babel-italian cm-super greek-fontenc latexmk fancyhdr
 ```
 
 As you can see `tlmgr` asks for admin rights, so you'll need to use `sudo` on Linux/macOS, while on Windows you have to [open a command prompt instance as admin](https://www.makeuseof.com/windows-run-command-prompt-admin/) and omit the `sudo` at the beginning of the lines.


### PR DESCRIPTION
### Requisiti

Nessun pacchetto esterno aggiuntivo

### Descrizione delle modifiche

Aggiornati alcuni pacchetti segnalati obsoleti su CTAN: `chngpage`, `subfig`)
Aggiornato README: rimosso `subfig`, `subcaption` è contenuto in `caption` e `changepage` già presente

### Design Alternativi

Probabilmente altri pacchetti sono da rivedere

### Benefici

`subcaption` gestisce meglio i riferimenti

### Possibili regressioni

Non ne ho trovate ma non dovrebbero essere modifiche rischiose