### PR TITLE
Fix Margini Tesi Stampabile

### DIFF
--- a/printable-thesis.tex
+++ b/printable-thesis.tex
@@ -9,4 +9,5 @@
 
 \newcommand{\isprintable}{1}
 
+\usepackage[paper=a4paper,inner=4.5cm, outer=2.5cm]{geometry}
 \input{thesis}


### PR DESCRIPTION
### Requisiti
Pacchetto _geometry_

### Descrizione delle modifiche
Durante la compilazione del file `printable-thesis.tex`  la prima pagina del capitolo viene sempre allineata dal lato sbagliato (_inner_ e _outer_ invertiti, visibile anche dal posizionamento del numero di pagina). Con questa semplice modifica viene forzato il rispetto dei margini solo per la versione stampabile della tesi.


### Design Alternativi
N/R

### Benefici
Non servirà modificare a mano il margine di ogni singola pagina della versione stampabile

### Possibili regressioni
N/R, possibili modifiche estetiche solo sulla versione stampabile

### Issue coinvolte
N/R